### PR TITLE
Export Nitro instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ To leverage custom instrumentation, set `disableAutomaticInstrumentation` to `tr
 // ./server/plugins/instrumentation.ts
 import { defineNitroPlugin } from 'nitropack/runtime/plugin'
 import type { NitroApp } from 'nitropack/types'
+import { NitroInstrumentation } from '@scayle/nuxt-opentelemetry'
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics'
@@ -118,6 +119,7 @@ export default defineNitroPlugin((_nitroApp: NitroApp) => {
     }),
     instrumentations: [
       getNodeAutoInstrumentations(),
+      new NitroInstrumentation()
     ],
   })
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You can read more about the behavior of these options in [its documentation](htt
 
 ### Custom instrumentation
 
-To leverage custom instrumentation, set `disableAutomaticInstrumentation` to `true`. This enables the creation of custom instrumentation within a Nitro plugin located in the `./server/plugins` directory, offering enhanced customization and adaptability for your instrumentation configuration. The example provided demonstrates a basic instrumentation setup utilizing the `@opentelemetry/sdk-node`.
+To leverage custom instrumentation, set `disableAutomaticInitialization` to `true`. This enables the creation of custom instrumentation within a Nitro plugin located in the `./server/plugins` directory, offering enhanced customization and adaptability for your instrumentation configuration. The example provided demonstrates a basic instrumentation setup utilizing the `@opentelemetry/sdk-node`.
 
 ```ts
 // ./server/plugins/instrumentation.ts

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,6 +8,8 @@ import {
 import { defu } from 'defu'
 import { getPublicAssets, nitroSetup, prepareEntry } from './utils'
 
+export { NitroInstrumentation } from './runtime/instrumentation'
+
 export interface ModuleOptions {
   enabled: boolean
   pathBlocklist?: string


### PR DESCRIPTION
Exports the `NitroInstrumentation` class for use in custom OpenTelemetry setup, when automatic initialization is disabled, allowing for direct integration:

```ts
import { NitroInstrumentation } from '@scayle/nuxt-opentelemetry'
```

cc @cjpearson, @rpauls-scayle 